### PR TITLE
fix index dont start in 0 when torrent only have 1 file

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/torrentServer/TorrentServerUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/torrentServer/TorrentServerUtils.kt
@@ -22,7 +22,6 @@ object TorrentServerUtils {
         return mergedTrackerList.split(",").map { it.trim() }.filter { it.isNotBlank() }.joinToString("&tr=")
     }
 
-    // INDEX START IN 1
     fun getTorrentPlayLink(torr: Torrent, index: Int): String {
         val file = findFile(torr, index)
         val name = file?.let { File(it.path).name } ?: torr.title

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -1591,11 +1591,11 @@ class PlayerActivity : BaseActivity() {
                     TorrentServerService.wait(10)
                     val currentTorrent = TorrentServerApi.addTorrent(videoUrl, it.quality, "", "", false)
                     if (it.videoUrl!!.contains("index=")) {
-                        val index = it.videoUrl?.substringAfter("index=")?.toInt() ?: 1
+                        val index = it.videoUrl?.substringAfter("index=")?.toInt() ?: 0
                         val torrentUrl = TorrentServerUtils.getTorrentPlayLink(currentTorrent, index)
                         MPVLib.command(arrayOf("loadfile", torrentUrl))
                     } else {
-                        val torrentUrl = TorrentServerUtils.getTorrentPlayLink(currentTorrent, 1)
+                        val torrentUrl = TorrentServerUtils.getTorrentPlayLink(currentTorrent, 0)
                         MPVLib.command(arrayOf("loadfile", torrentUrl))
                     }
                 }

--- a/go/torrserver/web/api/stream.go
+++ b/go/torrserver/web/api/stream.go
@@ -121,7 +121,7 @@ func stream(c *gin.Context) {
 	// find file
 	index := -1
 	if len(tor.Files()) == 1 {
-		index = 1
+		index = 0
 	} else {
 		ind, err := strconv.Atoi(indexStr)
 		if err == nil {
@@ -129,8 +129,7 @@ func stream(c *gin.Context) {
 		}
 	}
 	if index == -1 && play { // if file index not set and play file exec
-		c.AbortWithError(http.StatusBadRequest, errors.New("\"index\" is empty or wrong"))
-		return
+		index = 0
 	}
 	// preload torrent
 	if preload {
@@ -211,7 +210,7 @@ func streamNoAuth(c *gin.Context) {
 	// find file
 	index := -1
 	if len(tor.Files()) == 1 {
-		index = 1
+		index = 0
 	} else {
 		ind, err := strconv.Atoi(indexStr)
 		if err == nil {
@@ -219,8 +218,7 @@ func streamNoAuth(c *gin.Context) {
 		}
 	}
 	if index == -1 && play { // if file index not set and play file exec
-		c.AbortWithError(http.StatusBadRequest, errors.New("\"index\" is empty or wrong"))
-		return
+		index = 0
 	}
 	// preload torrent
 	if preload {


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
with the changes in 2b1fce033a462de07ece49bbaf88943e79841168 now the file indexes start at 0